### PR TITLE
add `.get_mode` getter

### DIFF
--- a/R/widget.R
+++ b/R/widget.R
@@ -185,6 +185,12 @@ AnyHtmlWidget <- R6::R6Class("AnyHtmlWidget",
       return(private$.height)
     },
     #' @description
+    #' Get the server port.
+    #' @returns The port number.
+    .get_mode = function() {
+      return(private$.mode)
+    },
+    #' @description
     #' Set all values. TODO: is this ever used?
     #' @param new_values A list of new values.
     .set_values = function(new_values) {


### PR DESCRIPTION
Perhaps, there is a reason for no `.get_mode`, but I am guessing that `.mode` was inadvertently missed in the getters.